### PR TITLE
Implement the skeleton of FeedbackGuidedStrategy.

### DIFF
--- a/Src/PChecker/CheckerCore/Coverage/ActorRuntimeLogEventCoverage.cs
+++ b/Src/PChecker/CheckerCore/Coverage/ActorRuntimeLogEventCoverage.cs
@@ -101,6 +101,8 @@ namespace PChecker.Coverage
                 eventSet.UnionWith(pair.Value);
             }
         }
+
+        public override int GetHashCode() => (EventsSent, EventsReceived).GetHashCode();
     }
 
     internal class ActorRuntimeLogEventCoverage : IActorRuntimeLog

--- a/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/FeedbackGuidedStrategy.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/Strategies/Feedback/FeedbackGuidedStrategy.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PChecker.Actors;
+using PChecker.Random;
+using PChecker.SystematicTesting.Operations;
+
+namespace PChecker.SystematicTesting.Strategies.Feedback;
+
+record StrategyInputGenerator(IRandomValueGenerator InputGenerator, IRandomValueGenerator ScheduleGenerator);
+internal class FeedbackGuidedStrategy : ISchedulingStrategy
+{
+    private StrategyInputGenerator _generator;
+
+    private readonly int _maxScheduledSteps;
+
+    private int _scheduledSteps;
+
+    private readonly CheckerConfiguration _checkerConfiguration;
+
+    private readonly HashSet<int> _visitedStates = new();
+
+    private readonly LinkedList<StrategyInputGenerator> _savedGenerators = new();
+
+    private readonly int _maxMutations = 50;
+
+    private int _numMutations = 0;
+
+    private LinkedListNode<StrategyInputGenerator>? _currentNode = null;
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FeedbackGuidedStrategy"/> class.
+    /// </summary>
+    public FeedbackGuidedStrategy(CheckerConfiguration checkerConfiguration)
+    {
+        _maxScheduledSteps = checkerConfiguration.MaxFairSchedulingSteps;
+        _checkerConfiguration = checkerConfiguration;
+        _generator = new StrategyInputGenerator(new RandomValueGenerator(_checkerConfiguration),
+            new RandomValueGenerator(_checkerConfiguration));
+    }
+
+    /// <inheritdoc/>
+    public bool GetNextOperation(AsyncOperation current, IEnumerable<AsyncOperation> ops, out AsyncOperation next)
+    {
+        var enabledOperations = ops.Where(op => op.Status is AsyncOperationStatus.Enabled).ToList();
+        if (enabledOperations.Count == 0)
+        {
+            next = null;
+            return false;
+        }
+
+        var idx = _generator.ScheduleGenerator.Next(enabledOperations.Count);
+        next = enabledOperations[idx];
+
+        _scheduledSteps++;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public bool GetNextBooleanChoice(AsyncOperation current, int maxValue, out bool next)
+    {
+        next = _generator.InputGenerator.Next(maxValue) == 0;
+
+        _scheduledSteps++;
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public bool GetNextIntegerChoice(AsyncOperation current, int maxValue, out int next)
+    {
+        next = _generator.InputGenerator.Next(maxValue);
+        _scheduledSteps++;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public bool PrepareForNextIteration()
+    {
+        // Noop
+        _scheduledSteps = 0;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public int GetScheduledSteps()
+    {
+        return _scheduledSteps;
+    }
+
+    /// <inheritdoc/>
+    public bool HasReachedMaxSchedulingSteps()
+    {
+        if (_maxScheduledSteps == 0)
+        {
+            return false;
+        }
+
+        return _scheduledSteps >= _maxScheduledSteps;
+    }
+
+    /// <inheritdoc/>
+    public bool IsFair()
+    {
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public string GetDescription()
+    {
+        return "feedback";
+    }
+
+    /// <inheritdoc/>
+    public void Reset()
+    {
+        _scheduledSteps = 0;
+    }
+
+    /// <summary>
+    /// This method observes the results of previous run and prepare for the next run.
+    /// </summary>
+    /// <param name="runtime">The ControlledRuntime of previous run.</param>
+    public void ObserveRunningResults(ControlledRuntime runtime)
+    {
+        // TODO: implement real feedback.
+        int stateHash = runtime.GetCoverageInfo().EventInfo.GetHashCode();
+        if (!_visitedStates.Contains(stateHash))
+        {
+            _savedGenerators.AddLast(_generator);
+        }
+        PrepareNextInput();
+    }
+
+    private void PrepareNextInput()
+    {
+        if (_savedGenerators.Count == 0)
+        {
+            // Create a new input if no input is saved.
+            _generator = new StrategyInputGenerator(new RandomValueGenerator(_checkerConfiguration),
+                new RandomValueGenerator(_checkerConfiguration));
+            return;
+        }
+        if (_numMutations == _maxMutations)
+        {
+            _currentNode = _currentNode?.Next;
+        }
+        _currentNode ??= _savedGenerators.First;
+        _generator = MutateGenerator(_currentNode!.Value);
+    }
+
+    private StrategyInputGenerator MutateGenerator(StrategyInputGenerator prev)
+    {
+        // TODO: implement real mutation strategies.
+        return new StrategyInputGenerator(new RandomValueGenerator(_checkerConfiguration),
+            new RandomValueGenerator(_checkerConfiguration));
+    }
+}

--- a/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
+++ b/Src/PChecker/CheckerCore/SystematicTesting/TestingEngine.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.SqlTypes;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -22,6 +23,7 @@ using PChecker.Random;
 using PChecker.Runtime;
 using PChecker.SystematicTesting.Strategies;
 using PChecker.SystematicTesting.Strategies.Exhaustive;
+using PChecker.SystematicTesting.Strategies.Feedback;
 using PChecker.SystematicTesting.Strategies.Probabilistic;
 using PChecker.SystematicTesting.Strategies.Special;
 using PChecker.SystematicTesting.Traces;
@@ -250,6 +252,10 @@ namespace PChecker.SystematicTesting
             {
                 Strategy = new DFSStrategy(checkerConfiguration.MaxUnfairSchedulingSteps);
             }
+            else if (checkerConfiguration.SchedulingStrategy is "feedback")
+            {
+                Strategy = new FeedbackGuidedStrategy(_checkerConfiguration);
+            }
             else if (checkerConfiguration.SchedulingStrategy is "portfolio")
             {
                 Error.ReportAndExit("Portfolio testing strategy is only " +
@@ -460,6 +466,11 @@ namespace PChecker.SystematicTesting
                 foreach (var callback in PerIterationCallbacks)
                 {
                     callback(iteration);
+                }
+
+                if (Strategy is FeedbackGuidedStrategy strategy)
+                {
+                    strategy.ObserveRunningResults(runtime);
                 }
 
                 // Checks that no monitor is in a hot state at termination. Only

--- a/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
+++ b/Src/PCompiler/PCommandLine/Options/PCheckerOptions.cs
@@ -50,6 +50,7 @@ namespace Plang.Options
             
             var schedulingGroup = Parser.GetOrCreateGroup("scheduling", "Search prioritization options");
             schedulingGroup.AddArgument("sch-random", null, "Choose the random scheduling strategy (this is the default)", typeof(bool));
+            schedulingGroup.AddArgument("sch-feedback", null, "Choose the feedback scheduling strategy", typeof(bool));
             schedulingGroup.AddArgument("sch-probabilistic", "sp", "Choose the probabilistic scheduling strategy with given probability for each scheduling decision where the probability is " +
                                                                    "specified as the integer N in the equation 0.5 to the power of N.  So for N=1, the probability is 0.5, for N=2 the probability is 0.25, N=3 you get 0.125, etc.", typeof(uint));
             schedulingGroup.AddArgument("sch-pct", null, "Choose the PCT scheduling strategy with given maximum number of priority switch points", typeof(uint));
@@ -163,6 +164,7 @@ namespace Plang.Options
                     checkerConfiguration.RandomGeneratorSeed = (uint)option.Value;
                     break;
                 case "sch-random":
+                case "sch-feedback":
                     checkerConfiguration.SchedulingStrategy = option.LongName.Substring(4);
                     break;
                 case "sch-probabilistic":
@@ -263,6 +265,7 @@ namespace Plang.Options
 
             if (checkerConfiguration.SchedulingStrategy != "portfolio" &&
                 checkerConfiguration.SchedulingStrategy != "random" &&
+                checkerConfiguration.SchedulingStrategy != "feedback" &&
                 checkerConfiguration.SchedulingStrategy != "pct" &&
                 checkerConfiguration.SchedulingStrategy != "fairpct" &&
                 checkerConfiguration.SchedulingStrategy != "probabilistic" &&


### PR DESCRIPTION
This PR implements the skeleton of `FeedbackGuidedStrategy` including the following logic:

1. Record the inputs which provides more coverage
2. Mutate previous saved inputs

Note that the current implementation only contains glue code and should be replaced with real implementations when stream-based input generator and state feedback is implemented. 
 